### PR TITLE
فایل بدون پسوند

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -258,4 +258,16 @@ if __name__ == '__main__':
 			print("فایل مورد نظر وجود ندارد")
 			
 	else:
-		print('فایل باید دارای پسوند fd باشد')
+		try:
+			filename = argv[1] + '.fd'
+			with open(filename, encoding="utf-8") as f:
+				for line in f.read().splitlines():
+					try:
+						tokens = lexer.tokenize(line)
+						tree = parser.parse(tokens)
+						PPLExecute(tree, env)
+					except:
+						print("دستور نادرست: %s" % line)
+						quit()
+		except:
+			print('فایل باید دارای پسوند fd باشد')


### PR DESCRIPTION
ممکن است کاربر پسوند فایل را ننویسد ( مخصوص تازه کاران)
آن موقع به آخر آرگومان پسوند اف دی را اضافه کرده و دنبال فایل می گردد و اگر وجود نداشت ، خطای مربوطه را می دهد